### PR TITLE
Command Line Switches and Other New Features

### DIFF
--- a/get-fav.php
+++ b/get-fav.php
@@ -44,47 +44,130 @@ https://github.com/audreyr/favicon-cheat-sheet
 
 ###### Copyright 2019-2020 Igor Gaffling
 
-*/ 
+*/
 
-$testURLs = array(
-  'http://aws.amazon.com',
-  'http://www.apple.com',
-  'http://www.dribbble.com',
-  'http://www.github.com',
-  'http://www.intercom.com',
-  'http://www.indiehackers.com',
-  'http://www.medium.com',
-  'http://www.mailchimp.com',
-  'http://www.netflix.com',
-  'http://www.producthunt.com',
-  'http://www.reddit.com',
-  'http://www.slack.com',
-  'http://www.soundcloud.com',
-  'http://www.stackoverflow.com',
-  'http://www.techcrunch.com',
-  'http://www.trello.com',
-  'http://www.vimeo.com',
-  'https://www.whatsapp.com/',
-  'https://www.gaffling.com/',
+/* Defaults */
+
+$console_mode = false;
+$localPath = ".";
+$save_local = true;
+$try_homepage = true;
+$debug = null;
+$testURLs = array();
+
+/* Command Line Options */
+$shortopts  = "";
+$shortopts  = "l::";
+$shortopts  = "p::";
+$shortopts .= "h?";
+
+$longopts  = array(
+  "list::",
+  "path::",
+  "usestdin",
+  "tryhomepage",
+  "onlyuseapis",
+  "store",
+  "nostore",
+  "debug",
+  "help",
 );
+
+$options = getopt($shortopts, $longopts);
+
+/* Process Options */
+
+$opt_list = null;
+$opt_localpath = null;
+$opt_usestdin = null;
+$opt_tryhomepage = null;
+$opt_storelocal = null;
+$opt_debug = null;
+
+if (isset($options['list'])) { $opt_list = $options['list']; }
+if (isset($options['path'])) { $opt_localpath = $options['path']; }
+if (isset($options['l'])) { $opt_list = $options['l']; }
+if (isset($options['p'])) { $opt_localpath = $options['p']; }
+if (isset($options['store'])) { $opt_storelocal = true; }
+if (isset($options['nostore'])) { $opt_storelocal = false; }
+if (isset($options['tryhomepage'])) { $opt_tryhomepage = true; }
+if (isset($options['onlyuseapis'])) { $opt_tryhomepage = false; }
+if (isset($options['debug'])) { $opt_debug = true; }
+
+if (!is_null($opt_localpath)) { $localPath = $opt_localpath; }
+if (!is_null($opt_tryhomepage)) { $try_homepage = $opt_tryhomepage; }
+if (!is_null($opt_storelocal)) { $save_local = $opt_storelocal; }
+if (!is_null($opt_storelocal)) { $save_local = $opt_storelocal; }
+if (!is_null($opt_debug)) { if ($opt_debug) { $debug = "true"; } else { $debug = null; } }
+
+# TO DO:
+# stdin
+
+if (isset($opt_list)) {
+  if (file_exists($opt_list)) {
+    $testURLs = file($opt_list,FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+  } else {
+    if (count($testURLs) == 0) {
+      $testURLs = explode(",",str_replace(array(",",";"," "),",",$opt_list));
+    }
+  }
+}
+
+if (count($testURLs) == 0) {
+  $testURLs = array(
+    'http://aws.amazon.com',
+    'http://www.apple.com',
+    'http://www.dribbble.com',
+    'http://www.github.com',
+    'http://www.intercom.com',
+    'http://www.indiehackers.com',
+    'http://www.medium.com',
+    'http://www.mailchimp.com',
+    'http://www.netflix.com',
+    'http://www.producthunt.com',
+    'http://www.reddit.com',
+    'http://www.slack.com',
+    'http://www.soundcloud.com',
+    'http://www.stackoverflow.com',
+    'http://www.techcrunch.com',
+    'http://www.trello.com',
+    'http://www.vimeo.com',
+    'https://www.whatsapp.com/',
+    'https://www.gaffling.com/',
+  );
+}
+
+# TO DO
+# check to see that save location is writable if enabled
+
 
 foreach ($testURLs as $url) {
   $grap_favicon = array(
     'URL' => $url,   // URL of the Page we like to get the Favicon from
-    'SAVE'=> true,   // Save Favicon copy local (true) or return only favicon url (false)
-    'DIR' => './',   // Local Dir the copy of the Favicon should be saved
-    'TRY' => true,   // Try to get the Favicon frome the page (true) or only use the APIs (false)
-    'DEV' => null,   // Give all Debug-Messages ('debug') or only make the work (null)
+    'SAVE'=> $save_local,   // Save Favicon copy local (true) or return only favicon url (false)
+    'DIR' => $localPath,   // Local Dir the copy of the Favicon should be saved
+    'TRY' => $try_homepage,   // Try to get the Favicon frome the page (true) or only use the APIs (false)
+    'DEV' => $debug,   // Give all Debug-Messages ('debug') or only make the work (null)
   );
   $favicons[] = grap_favicon($grap_favicon);
 }
+
 foreach ($favicons as $favicon) {
-  echo '<img title="'.$favicon.'" style="width:32px;padding-right:32px;" src="'.$favicon.'">';
+  if ($console_mode) {
+    echo "Icon: $ravicon\n";
+  } else {
+    echo '<img title="'.$favicon.'" style="width:32px;padding-right:32px;" src="'.$favicon.'">';
+  }
 }
-echo '<br><br><tt>Runtime: '.round((microtime(true)-$_SERVER["REQUEST_TIME_FLOAT"]),2).' Sec.';
+
+if ($console_mode) {
+  # TO DO: console runtime timer
+} else {
+  echo '<br><br><tt>Runtime: '.round((microtime(true)-$_SERVER["REQUEST_TIME_FLOAT"]),2).' Sec.';
+}
 
 function grap_favicon( $options=array() ) {
-  
+
   // avoid script runtime timeout
   $max_execution_time = ini_get("max_execution_time");
   set_time_limit(0); // 0 = no timelimit
@@ -119,15 +202,18 @@ function grap_favicon( $options=array() ) {
 	// FOR DEBUG ONLY
 	if($DEBUG=='debug')print('<b style="color:red;">Domain</b> #'.@$domain.'#<br>');
 
+  # TO DO: 
+  # this needs to check for different types
+  
 	// Make Path & Filename
 	$filePath = preg_replace('#\/\/#', '/', $directory.'/'.$domain.'.png');
-	// change save path & filename of icons ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
+	// change save path & filename of icons ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 	// If Favicon not already exists local
   if ( !file_exists($filePath) or @filesize($filePath)==0 ) {
 
     // If $trySelf == TRUE ONLY USE APIs
-    if ( isset($trySelf) and $trySelf == TRUE ) {  
+    if ( isset($trySelf) and $trySelf == TRUE ) {
 
       // Load Page
       $html = load($url, $DEBUG);
@@ -138,19 +224,19 @@ function grap_favicon( $options=array() ) {
         $regExPattern = '/href=(\'|\")(.*?)\1/i';
         if ( isset($matchTag[1]) and @preg_match($regExPattern, $matchTag[1], $matchUrl)) {
           if ( isset($matchUrl[2]) ) {
-            
+
             // Build Favicon Link
             $favicon = rel2abs(trim($matchUrl[2]), 'http://'.$domain.'/');
-            
+
           	// FOR DEBUG ONLY
           	if($DEBUG=='debug')print('<b style="color:red;">Match</b> #'.@$favicon.'#<br>');
 
           }
         }
       }
-      
+
       // If there is no Match: Try if there is a Favicon in the Root of the Domain
-    	if ( empty($favicon) ) { 
+    	if ( empty($favicon) ) {
       	$favicon = 'http://'.$domain.'/favicon.ico';
 
       	// Try to Load Favicon
@@ -160,7 +246,7 @@ function grap_favicon( $options=array() ) {
     	}
 
     } // END If $trySelf == TRUE ONLY USE APIs
-        
+
     // If nothink works: Get the Favicon from API
     if ( !isset($favicon) or empty($favicon) ) {
 
@@ -175,7 +261,7 @@ function grap_favicon( $options=array() ) {
       // Favicongrabber API
       if ($random == 2 or empty($favicon)) {
         $echo = json_decode(load('http://favicongrabber.com/api/grab/'.$domain,FALSE),TRUE);
-        
+
         // Get Favicon URL from Array out of json data (@ if something went wrong)
         $favicon = @$echo['icons']['0']['src'];
 
@@ -184,42 +270,58 @@ function grap_favicon( $options=array() ) {
       // Google API (check also md5() later)
       if ($random == 3) {
         $favicon = 'http://www.google.com/s2/favicons?domain='.$domain;
-      } 
-      
+      }
+
       // FOR DEBUG ONLY
       if($DEBUG=='debug')print('<b style="color:red;">'.$random.'. API</b> #'.@$favicon.'#<br>');
 
     } // END If nothink works: Get the Favicon from API
 
-    // Write Favicon local
-    $filePath = preg_replace('#\/\/#', '/', $directory.'/'.$domain.'.png');
 
     // If Favicon should be saved
     if ( isset($save) and $save == TRUE ) {
-      
+      echo "Saving, loading $favicon\n";
+
       //  Load Favicon
       $content = load($favicon, $DEBUG);
-
+      echo "loaded\n";
+      
       // If Google API don't know and deliver a default Favicon (World)
-      if ( isset($random) and $random == 3 and 
+      if ( isset($random) and $random == 3 and
            md5($content) == '3ca64f83fdcf25135d87e08af65e68c9' ) {
         $domain = 'default'; // so we don't save a default icon for every domain again
 
         // FOR DEBUG ONLY
         if($DEBUG=='debug')print('<b style="color:red;">Google</b> #use default icon#<br>');
-        
+
       }
 
-      // Write 
-      $fh = @fopen($filePath, 'wb');
-      fwrite($fh, $content);
-      fclose($fh);
+      //  Get Type
+      $fileExtension = geticonextension($favicon);
+      if (is_null($fileExtension)) {
+        if ($console_mode) {
+          if($DEBUG=='debug')print('Invalid File Type for $favicon\n');
+        } else {
+          if($DEBUG=='debug')print('<b style="color:red;">Write-File</b> #INVALID_IMAGE#<br>');
+        }
+      } else {
+        $filePath = preg_replace('#\/\/#', '/', $directory.'/'.$domain.'.'.$fileExtension);
+        
+        // Write
+        $fh = @fopen($filePath, 'wb');
+        fwrite($fh, $content);
+        fclose($fh);
 
-      // FOR DEBUG ONLY
-    	if($DEBUG=='debug')print('<b style="color:red;">Write-File</b> #'.@$filePath.'#<br>');
+        // FOR DEBUG ONLY
+        if ($console_mode) {
+          if($DEBUG=='debug')print('Writing File $filepath\n');
+        } else {
+          if($DEBUG=='debug')print('<b style="color:red;">Write-File</b> #'.@$filePath.'#<br>');
+        }
+      }
 
     } else {
-      
+
       // Don't save Favicon local, only return Favicon URL
       $filePath = $favicon;
     }
@@ -239,10 +341,10 @@ function grap_favicon( $options=array() ) {
     } else {
       $content = file_get_contents($filePath);
     }
-	  print('<b style="color:red;">Image</b> <img style="width:32px;" 
+	  print('<b style="color:red;">Image</b> <img style="width:32px;"
 	         src="data:image/png;base64,'.base64_encode($content).'"><hr size="1">');
   }
-	
+
   // reset script runtime timeout
   set_time_limit($max_execution_time); // set it back to the old value
 
@@ -297,4 +399,20 @@ function rel2abs( $rel, $base ) {
 	$abs = preg_replace( "/(\/\.?\/)/", "/", $abs);
 	$abs = preg_replace( "/\/(?!\.\.)[^\/]+\/\.\.\//", "/", $abs);
 	return $scheme . '://' . $abs;
+}
+
+/* GET ICON IMAGE TYPE  */
+function geticonextension( $url ) {
+  $filetype = exif_imagetype($url);
+  $retval = null;
+  if ($filetype) {
+    if ($filetype == IMAGETYPE_GIF) { $retval = "gif"; }
+    if ($filetype == IMAGETYPE_JPEG) { $retval = "jpg"; }
+    if ($filetype == IMAGETYPE_PNG) { $retval = "png"; }
+    if ($filetype == IMAGETYPE_ICO) { $retval = "ico"; }
+    if ($filetype == IMAGETYPE_WEBP) { $retval = "webp"; }
+    if ($filetype == IMAGETYPE_BMP) { $retval = "bmp"; }
+    if ($filetype == IMAGETYPE_GIF) { $retval = "gif"; }
+  }
+  return $retval;
 }

--- a/get-fav.php
+++ b/get-fav.php
@@ -74,6 +74,8 @@ $shortopts .= "h?";
 $longopts  = array(
   "list::",
   "path::",
+  "user-agent::",
+  "curl-timeout::",
   "tryhomepage",
   "onlyuseapis",
   "store",
@@ -82,6 +84,7 @@ $longopts  = array(
   "nosave",
   "overwrite",
   "skip",
+  "curl-verbose",
   "consolemode",
   "noconsolemode",
   "debug",
@@ -94,18 +97,21 @@ $options = getopt($shortopts, $longopts);
 if ((isset($options['help'])) || (isset($options['h'])) || (isset($options['?'])))
 {
   echo "Usage: $script_name (Switches)\n\n";
-  echo "--list=FILE/LIST  Filename or a delimited list of URLs to check.  Lists can be separated with space, comma or semi-colon.\n";
-  echo "--path=PATH       Location to store icons (default is $localPath)\n";
+  echo "--list=FILE/LIST            Filename or a delimited list of URLs to check.  Lists can be separated with space, comma or semi-colon.\n";
+  echo "--path=PATH                 Location to store icons (default is $localPath)\n";
   echo "\n";
-  echo "--tryhomepage     Try homepage first, then APIs.  (default is true)\n";
-  echo "--onlyuseapis     Only use APIs.\n";
-  echo "--store           Store favicons locally. (default is true)\n";
-  echo "--nostore         Do not store favicons locally.\n";
-  echo "--overwrite       Overwrite local favicons (default is false)\n";
-  echo "--skip            Skip local favicons if they are already present. (default is true)\n";
-  echo "--consolemode     Force console output.\n";
-  echo "--noconsolemode   Force HTML output.\n";
-  echo "--debug           Enable debug messages.\n";
+  echo "--tryhomepage               Try homepage first, then APIs.  (default is true)\n";
+  echo "--onlyuseapis               Only use APIs.\n";
+  echo "--store                     Store favicons locally. (default is true)\n";
+  echo "--nostore                   Do not store favicons locally.\n";
+  echo "--overwrite                 Overwrite local favicons (default is false)\n";
+  echo "--skip                      Skip local favicons if they are already present. (default is true)\n";
+  echo "--consolemode               Force console output.\n";
+  echo "--noconsolemode             Force HTML output.\n";
+  echo "--debug                     Enable debug messages.\n";
+  echo "--user-agent=AGENT_STRING   Customize the user agent.\n";
+  echo "--curl-verbose              Enable cURL verbose.\n";
+  echo "--curl-timeout=SECONDS      Set cURL timeeout (default is 60).\n";
   echo "\n";
   exit;
 }
@@ -119,6 +125,10 @@ $opt_tryhomepage = null;
 $opt_storelocal = null;
 $opt_debug = null;
 $opt_console = null;
+$opt_timeout = null;
+$opt_curl_user_agent = null;
+$opt_curl_verbose = false;
+$opt_curl_timeout = null;
 
 if (isset($options['debug'])) { $opt_debug = true; }
 if (isset($options['list'])) { $opt_list = $options['list']; }
@@ -135,12 +145,16 @@ if (isset($options['nosave'])) { $opt_storelocal = false; }
 if (isset($options['onlyuseapis'])) { $opt_tryhomepage = false; }
 if (isset($options['noconsolemode'])) { $opt_console = false; }
 if (isset($options['overwrite'])) { $overWrite = true; }
+if (isset($options['user-agent'])) { $opt_curl_user_agent = $options['user-agent']; }
+if (isset($options['curl-verbose'])) { $opt_curl_verbose = true; }
+if (isset($options['curl-timeout'])) { $opt_curl_timeout = $options['curl-timeout']; }
 
 if (!is_null($opt_localpath)) { if (file_exists($opt_localpath)) { $localPath = $opt_localpath; } }
 if (!is_null($opt_tryhomepage)) { $tryHomepage = $opt_tryhomepage; }
 if (!is_null($opt_storelocal)) { $saveLocal = $opt_storelocal; }
 if (!is_null($opt_debug)) { if ($opt_debug) { $debug = "debug"; } else { $debug = null; } }
 if (!is_null($opt_console)) { $consoleMode = $opt_console; }
+if (!is_null($opt_curl_timeout)) { if (is_numeric($opt_curl_timeout)) { if ($opt_curl_timeout >= 0 && $opt_curl_timeout < 600) { $opt_timeout = $opt_curl_timeout; } } }
 
 if (isset($opt_list)) {
   if (file_exists($opt_list)) {
@@ -151,6 +165,11 @@ if (isset($opt_list)) {
     }
   }
 }
+
+if (is_null($opt_curl_user_agent)) { if (isset($_SERVER['SERVER_NAME'])) { $opt_curl_user_agent = 'FaviconBot/1.0 (+http://'.$_SERVER['SERVER_NAME'].'/'; } else { $opt_curl_user_agent = 'FaviconBot/1.0/'; } }
+if (strtolower($opt_curl_user_agent) != "none") { setGlobal('curl_useragent', $opt_curl_user_agent); }
+setGlobal('curl_verbose', $opt_curl_verbose);
+if (!is_null($opt_timeout)) { setGlobal('curl_timeout', $opt_timeout); }
 
 if (count($testURLs) == 0) {
   $testURLs = array(
@@ -189,31 +208,31 @@ foreach ($testURLs as $url) {
 }
 
 foreach ($favicons as $favicon) {
-  if ($consoleMode) {
-    echo "Icon: $favicon\n";
-  } else {
-    echo '<img title="'.$favicon.'" style="width:32px;padding-right:32px;" src="'.$favicon.'">';
+  if (!empty($favicon))
+  {
+    if ($consoleMode) {
+      echo "Icon: $favicon\n";
+    } else {
+      echo '<img title="'.$favicon.'" style="width:32px;padding-right:32px;" src="'.$favicon.'">';
+    }
   }
 }
 
-$time_finish = microtime(true);
-$time_elapsed = $time_finish - $time_start;
-
 if ($consoleMode) {
-  echo "\nRuntime: ".round($time_elapsed,2)." Sec.\n";
+  echo "\nRuntime: ".round(microtime(true)-$time_start,2)." Sec.\n";
 } else {
   echo '<br><br><tt>Runtime: '.round((microtime(true)-$_SERVER["REQUEST_TIME_FLOAT"]),2).' Sec.';
 }
 
 /*  FUNCTIONS */
-function grap_favicon( $options=array(), $consoleMode ) {
-
-  if (!$consoleMode)
-  {
+function grap_favicon($options=array(), $consoleMode = false) {
+  if (!$consoleMode) {
     // avoid script runtime timeout
     $max_execution_time = ini_get("max_execution_time");
     set_time_limit(0); // 0 = no timelimit
   }
+
+  $curlTimeout = getGlobal('curl_timeout');
 
   // Ini Vars
   $url       = (isset($options['URL']))?$options['URL']:'gaffling.com';
@@ -251,72 +270,125 @@ function grap_favicon( $options=array(), $consoleMode ) {
   }
 
   // If $trySelf == TRUE ONLY USE APIs
-  if ( isset($trySelf) and $trySelf == TRUE ) {
+  if (isset($trySelf) && $trySelf == TRUE) {
 
     // Load Page
-    $html = load($url, $DEBUG, $consoleMode);
+    $html = load($url, $DEBUG, $consoleMode, $curlTimeout);
 
-    // Find Favicon with RegEx
-    $regExPattern = '/((<link[^>]+rel=.(icon|shortcut icon|alternate icon)[^>]+>))/i';
-    if ( @preg_match($regExPattern, $html, $matchTag) ) {
-      $regExPattern = '/href=(\'|\")(.*?)\1/i';
-      if ( isset($matchTag[1]) and @preg_match($regExPattern, $matchTag[1], $matchUrl)) {
-        if ( isset($matchUrl[2]) ) {
-
-          // Build Favicon Link
-          $favicon = rel2abs(trim($matchUrl[2]), 'http://'.$domain.'/');
-
-          // FOR DEBUG ONLY
+    if (empty($html)) {
+      if ($consoleMode) {
+        if($DEBUG=='debug')echo "No data received\n";
+      }
+    } else {
+      if ($consoleMode) {
+        if($DEBUG=='debug')echo "Attempting RegEx Match\n";
+      }
+      // Find Favicon with RegEx
+      $regExPattern = '/((<link[^>]+rel=.(icon|shortcut\sicon|alternate\sicon)[^>]+>))/i';
+      if (@preg_match($regExPattern, $html, $matchTag)) {
+        if ($consoleMode) {
+          if($DEBUG=='debug')echo "RegEx Initial Pattern Matched\n";
+          if($DEBUG=='debug')print_r($matchTag) . "\n";
+        }
+        $regExPattern = '/href=(\'|\")(.*?)\1/i';
+        if (isset($matchTag[1]) && @preg_match($regExPattern, $matchTag[1], $matchUrl)) {
           if ($consoleMode) {
-            if($DEBUG=='debug')echo "Match $favicon\n";
-          } else {
-            if($DEBUG=='debug')print('<b style="color:red;">Match</b> #'.@$favicon.'#<br>');
+            if($DEBUG=='debug')echo "RegEx Secondary Pattern Matched\n";
           }
+          if (isset($matchUrl[2])) {
+            if ($consoleMode) {
+              if($DEBUG=='debug')echo "Found Match, Building Link\n";
+            }
 
+            // Build Favicon Link
+            $favicon = rel2abs(trim($matchUrl[2]), 'http://'.$domain.'/');
+
+            // FOR DEBUG ONLY
+            if ($consoleMode) {
+              if($DEBUG=='debug')echo "Match $favicon\n";
+            } else {
+              if($DEBUG=='debug')print('<b style="color:red;">Match</b> #'.@$favicon.'#<br>');
+            }
+          } else {
+            if ($consoleMode) {
+              if($DEBUG=='debug')echo "Failed To Find Match\n";
+            }
+          }
+        } else {
+          if ($consoleMode) {
+            if($DEBUG=='debug')echo "RegEx Secondary Pattern Failed To Match\n";
+          }
+        }
+      } else {
+        if ($consoleMode) {
+          if($DEBUG=='debug')echo "RegEx Initial Pattern Failed To Match\n";
         }
       }
     }
 
     // If there is no Match: Try if there is a Favicon in the Root of the Domain
-    if ( empty($favicon) ) {
+    if (empty($favicon)) {
       $favicon = 'http://'.$domain.'/favicon.ico';
+      if ($consoleMode) {
+        if($DEBUG=='debug')echo "Attempting Direct Match\n";
+      }
 
       // Try to Load Favicon
-      if ( !@getimagesize($favicon) ) {
+      # if ( !@getimagesize($favicon) ) {
+      # https://www.php.net/manual/en/function.getimagesize.php
+      # Do not use getimagesize() to check that a given file is a valid image.
+      if ($consoleMode) {
+        if($DEBUG=='debug')echo "$favicon\n";
+      }
+      $fileExtension = geticonextension($favicon,false);
+      if (is_null($fileExtension)) {
         unset($favicon);
+        if ($consoleMode) {
+          if($DEBUG=='debug')echo "Failed Direct Match\n";
+        }
       }
     }
-
   } // END If $trySelf == TRUE ONLY USE APIs
 
   // If nothink works: Get the Favicon from API
-  if ( !isset($favicon) or empty($favicon) ) {
+  if ((!isset($favicon)) || (empty($favicon))) {
+    if ($consoleMode) {
+      if($DEBUG=='debug')echo "Attempting API Match\n";
+    }
 
     // Select API by Random
     $random = rand(1,3);
 
     // Faviconkit API
-    if ($random == 1 or empty($favicon)) {
+    if (($random == 1) || (empty($favicon))) {
+      if ($consoleMode) {
+        if($DEBUG=='debug')echo "API: Selected FavIconKit\n";
+      }
       $favicon = 'https://api.faviconkit.com/'.$domain.'/16';
     }
 
     // Favicongrabber API
-    if ($random == 2 or empty($favicon)) {
+    if (($random == 2) || (empty($favicon))) {
+      if ($consoleMode) {
+        if($DEBUG=='debug')echo "API: Selected FavIconGrabber\n";
+      }
       $echo = json_decode(load('http://favicongrabber.com/api/grab/'.$domain,FALSE),TRUE);
 
       // Get Favicon URL from Array out of json data (@ if something went wrong)
       $favicon = @$echo['icons']['0']['src'];
-
     }
 
     // Google API (check also md5() later)
     if ($random == 3) {
+      if ($consoleMode) {
+        if($DEBUG=='debug')echo "API: Selected Google\n";
+      }
       $favicon = 'http://www.google.com/s2/favicons?domain='.$domain;
     }
 
     // FOR DEBUG ONLY
     if ($consoleMode) {
-      if($DEBUG=='debug')echo "$random API: $favicon\n";
+      if($DEBUG=='debug')echo "API ($random): Result: $favicon\n";
     } else {
       if($DEBUG=='debug')print('<b style="color:red;">'.$random.'. API</b> #'.@$favicon.'#<br>');
     }
@@ -325,57 +397,68 @@ function grap_favicon( $options=array(), $consoleMode ) {
 
 
   // If Favicon should be saved
-  if ( isset($save) and $save == TRUE ) {
+  if ((isset($save)) && ($save == TRUE)) {
+    unset($content);
 
-    //  Load Favicon
-    $content = load($favicon, $DEBUG, $consoleMode);
-
-    // If Google API don't know and deliver a default Favicon (World)
-    if ( isset($random) and $random == 3 and
-         md5($content) == '3ca64f83fdcf25135d87e08af65e68c9' ) {
-      $domain = 'default'; // so we don't save a default icon for every domain again
-
-      // FOR DEBUG ONLY
-      if ($consoleMode) {
-        if($DEBUG=='debug')echo "Google: #use default icon#\n";
-      } else {
-        if($DEBUG=='debug')print('<b style="color:red;">Google</b> #use default icon#<br>');
-      }
-
+    if ($consoleMode) {
+      if($DEBUG=='debug')echo "Attempting to load favicon\n";
     }
 
-    //  Get Type
-    $fileExtension = geticonextension($favicon);
-    if (is_null($fileExtension)) {
+    //  Load Favicon
+    $content = load($favicon, $DEBUG, $consoleMode, $curlTimeout);
+
+    if (empty($content)) {
       if ($consoleMode) {
-        if($DEBUG=='debug')echo "Invalid File Type for $favicon\n";
-      } else {
-        if($DEBUG=='debug')print('<b style="color:red;">Write-File</b> #INVALID_IMAGE#<br>');
+        if($DEBUG=='debug')echo "Failed to load favicon\n";
       }
     } else {
-      $filePath = preg_replace('#\/\/#', '/', $directory.'/'.$domain.'.'.$fileExtension);
+      // If Google API don't know and deliver a default Favicon (World)
+      if (isset($random) && $random == 3 && md5($content) == '3ca64f83fdcf25135d87e08af65e68c9') {
+        $domain = 'default'; // so we don't save a default icon for every domain again
 
-      //  If overwrite, delete it
-      if (file_exists($filePath)) { if ($overwrite) { unlink($filePath); } }
-
-      //  If file exists, skip
-      if (file_exists($filePath)) {
         // FOR DEBUG ONLY
         if ($consoleMode) {
-          if($DEBUG=='debug')echo "Skipping File $filePath\n";
+          if($DEBUG=='debug')echo "Google: #use default icon#\n";
         } else {
-          if($DEBUG=='debug')print('<b style="color:red;">Skip-File</b> #'.@$filePath.'#<br>');
+          if($DEBUG=='debug')print('<b style="color:red;">Google</b> #use default icon#<br>');
         }
-      } else {
-        // Write
-        $fh = @fopen($filePath, 'wb');
-        fwrite($fh, $content);
-        fclose($fh);
-        // FOR DEBUG ONLY
-        if ($consoleMode) {
-          if($DEBUG=='debug')echo "Writing File $filePath\n";
+      }
+
+      //  Get Type
+      if (!empty($favicon)) {
+        $fileExtension = geticonextension($favicon);
+        if (is_null($fileExtension)) {
+          if ($consoleMode) {
+            if($DEBUG=='debug')echo "Invalid File Type for $favicon\n";
+          } else {
+            if($DEBUG=='debug')print('<b style="color:red;">Write-File</b> #INVALID_IMAGE#<br>');
+          }
         } else {
-          if($DEBUG=='debug')print('<b style="color:red;">Write-File</b> #'.@$filePath.'#<br>');
+          $filePath = preg_replace('#\/\/#', '/', $directory.'/'.$domain.'.'.$fileExtension);
+
+          //  If overwrite, delete it
+          if (file_exists($filePath)) { if ($overwrite) { unlink($filePath); } }
+
+          //  If file exists, skip
+          if (file_exists($filePath)) {
+            // FOR DEBUG ONLY
+            if ($consoleMode) {
+              if($DEBUG=='debug')echo "Skipping File $filePath\n";
+            } else {
+              if($DEBUG=='debug')print('<b style="color:red;">Skip-File</b> #'.@$filePath.'#<br>');
+            }
+          } else {
+            // Write
+            $fh = @fopen($filePath, 'wb');
+            fwrite($fh, $content);
+            fclose($fh);
+            // FOR DEBUG ONLY
+            if ($consoleMode) {
+              if($DEBUG=='debug')echo "Writing File $filePath\n";
+            } else {
+              if($DEBUG=='debug')print('<b style="color:red;">Write-File</b> #'.@$filePath.'#<br>');
+            }
+          }
         }
       }
     }
@@ -387,25 +470,30 @@ function grap_favicon( $options=array(), $consoleMode ) {
 	// FOR DEBUG ONLY
 	if ($DEBUG=='debug') {
     // Load the Favicon from local file
-	  if ( !function_exists('file_get_contents') ) {
-      $fh = @fopen($filePath, 'r');
-      while (!feof($fh)) {
-        $content .= fread($fh, 128); // Because filesize() will not work on URLS?
+    if (!empty($filePath)) {
+      if (!function_exists('file_get_contents')) {
+        $fh = @fopen($filePath, 'r');
+        while (!feof($fh)) {
+          $content .= fread($fh, 128); // Because filesize() will not work on URLS?
+        }
+        fclose($fh);
+      } else {
+        $content = file_get_contents($filePath);
       }
-      fclose($fh);
-    } else {
-      $content = file_get_contents($filePath);
-    }
-    if ($consoleMode) {
-      echo geticonextension($filePath) . " format file loaded from $filePath\n";
-    } else {
-	  print('<b style="color:red;">Image</b> <img style="width:32px;"
-	         src="data:image/png;base64,'.base64_encode($content).'"><hr size="1">');
+      if ($consoleMode) {
+        echo geticonextension($filePath) . " format file loaded from $filePath\n";
+      } else {
+      print('<b style="color:red;">Image</b> <img style="width:32px;"
+             src="data:image/png;base64,'.base64_encode($content).'"><hr size="1">');
+      }
     }
   }
 
-  // reset script runtime timeout
-  set_time_limit($max_execution_time); // set it back to the old value
+
+  if (!$consoleMode) {
+    // reset script runtime timeout
+    set_time_limit($max_execution_time); // set it back to the old value
+  }
 
   // Return Favicon Url
   return $filePath;
@@ -413,10 +501,12 @@ function grap_favicon( $options=array(), $consoleMode ) {
 } // END MAIN Function
 
 /* HELPER load use curl or file_get_contents (both with user_agent) and fopen/fread as fallback */
-function load($url, $DEBUG, $consoleMode ) {
-  if ( function_exists('curl_version') ) {
+function load($url, $DEBUG, $consoleMode = false, $timeOut = 60) {
+  if (function_exists('curl_version')) {
     $ch = curl_init($url);
-    curl_setopt($ch, CURLOPT_USERAGENT, 'FaviconBot/1.0 (+http://'.$_SERVER['SERVER_NAME'].'/');
+    curl_setopt($ch, CURLOPT_USERAGENT, getGlobal('curl_useragent'));
+    curl_setopt($ch, CURLOPT_VERBOSE, getGlobal('curl_verbose'));
+    curl_setopt($ch, CURLOPT_TIMEOUT, $timeOut);
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
     curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
@@ -436,7 +526,7 @@ function load($url, $DEBUG, $consoleMode ) {
         'user_agent' => 'FaviconBot/1.0 (+http://'.$_SERVER['SERVER_NAME'].'/)'),
     );
     $context = stream_context_create($context);
-	  if ( !function_exists('file_get_contents') ) {
+	  if (!function_exists('file_get_contents')) {
       $fh = fopen($url, 'r', FALSE, $context);
       $content = '';
       while (!feof($fh)) {
@@ -451,13 +541,13 @@ function load($url, $DEBUG, $consoleMode ) {
 }
 
 /* HELPER: Change URL from relative to absolute */
-function rel2abs( $rel, $base ) {
-	extract( parse_url( $base ) );
-	if ( strpos( $rel,"//" ) === 0 ) return $scheme . ':' . $rel;
-	if ( parse_url( $rel, PHP_URL_SCHEME ) != '' ) return $rel;
-	if ( $rel[0] == '#' or $rel[0] == '?' ) return $base . $rel;
+function rel2abs($rel, $base) {
+	extract(parse_url($base));
+	if (strpos( $rel,"//" ) === 0) return $scheme . ':' . $rel;
+	if (parse_url( $rel, PHP_URL_SCHEME ) != '') return $rel;
+	if ($rel[0] == '#' or $rel[0] == '?') return $base . $rel;
 	$path = preg_replace( '#/[^/]*$#', '', $path);
-	if ( $rel[0] ==  '/' ) $path = '';
+	if ($rel[0] ==  '/') $path = '';
 	$abs = $host . $path . "/" . $rel;
 	$abs = preg_replace( "/(\/\.?\/)/", "/", $abs);
 	$abs = preg_replace( "/\/(?!\.\.)[^\/]+\/\.\.\//", "/", $abs);
@@ -465,22 +555,33 @@ function rel2abs( $rel, $base ) {
 }
 
 /* GET ICON IMAGE TYPE  */
-function geticonextension( $url ) {
-  // If exif_imagetype is not available, it will simply return the extension
-  if ( function_exists('exif_imagetype') ) {
-    $filetype = exif_imagetype($url);
-    $retval = null;
-    if ($filetype) {
-      if ($filetype == IMAGETYPE_GIF) { $retval = "gif"; }
-      if ($filetype == IMAGETYPE_JPEG) { $retval = "jpg"; }
-      if ($filetype == IMAGETYPE_PNG) { $retval = "png"; }
-      if ($filetype == IMAGETYPE_ICO) { $retval = "ico"; }
-      if ($filetype == IMAGETYPE_WEBP) { $retval = "webp"; }
-      if ($filetype == IMAGETYPE_BMP) { $retval = "bmp"; }
-      if ($filetype == IMAGETYPE_GIF) { $retval = "gif"; }
+function geticonextension($url, $noFallback = false) {
+  $retval = null;
+  if (!empty($url))
+  {
+    // If exif_imagetype is not available, it will simply return the extension
+    if (function_exists('exif_imagetype')) {
+      $filetype = @exif_imagetype($url);
+      if ($filetype) {
+        if ($filetype == IMAGETYPE_GIF) { $retval = "gif"; }
+        if ($filetype == IMAGETYPE_JPEG) { $retval = "jpg"; }
+        if ($filetype == IMAGETYPE_PNG) { $retval = "png"; }
+        if ($filetype == IMAGETYPE_ICO) { $retval = "ico"; }
+        if ($filetype == IMAGETYPE_WEBP) { $retval = "webp"; }
+        if ($filetype == IMAGETYPE_BMP) { $retval = "bmp"; }
+        if ($filetype == IMAGETYPE_GIF) { $retval = "gif"; }
+      }
+    } else {
+      if (!$noFallback) { $retval = @preg_replace('/^.*\.([^.]+)$/D', '$1', $url); }
     }
-  } else {
-    $retval = preg_replace('/^.*\.([^.]+)$/D', '$1', $url);
   }
   return $retval;
+}
+
+function setGlobal($variable,$value = null) {
+	$GLOBALS[$variable] = $value;
+}
+
+function getGlobal($variable) {
+	return $GLOBALS[$variable];
 }


### PR DESCRIPTION
### Overview

By it's design, it appears that the original use case had this run as a web script whereas I am using it as a command line tool so it should be tested for the various environments/use cases.

### Changes
- [x] Functions `grap_favicon` and `load` now have an additional parameter, `$consolemode` (default is false).
- [x] Function `load`  can also take a fourth parameter, $timeOut (default is 60)
- [x] `grap_favicon` array now has an additional parameter, `OVR` for overwriting files.  Default is `false`.
- [x] Command Line switches are implemented.   Any parameter with a space in it needs to be quoted.

**Command Line Switches:**
- [x] --list (or -l) can be a text file with a list or URLs or a , ; or space delimited list. (e.g. `--list=http://www.google.com,http://www.microsoft.com`  `--list=myfile.txt`)
- [x] --path (or -p), local save path (e.g. `--path="D:\My Icons\"`)
- [x] --store;  store local files (alias --save) (default)
- [x] --nostore; do not store local files (alias --nosave)
- [x] --tryhomepage; try homepage first (default)
- [x] --onlyuseapis; only use apis
- [x] --consolemode; output regular text
- [x] --noconsolemode; output html (default; subject to detection)
- [x] --overwrite (overwrite local file if present)
- [x] --skip (skip local file if present; default)
- [x] --curl-verbose (show curl verbose messages)
- [x] --curl-timeout (set curl timeout, default is 60) (e.g `--curl-timeout=30`)
- [x] --user-agent (specify a specific user agent) (e.g. `--user-agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/110.0.0.0 Safari/537.36"`)
- [x] --debug; enable debug mode
- [x] --help (or -? or -h)

Other Features:
- [x] Detects image format and saves the local file accordingly
- [x] Detects console or HTTP/CGI mode
- [x] "Console Mode" shows regular text instead of HTML 

Other Items:
- [x] Checks if local save path exists (if set other than default)
- [x] cURL timeout can be set but defaults to 60
- [x] "Console Mode" skips `set_time_limit`
- [x] "Console Mode"  shows a runtime total

### Usage Examples
`C:\php\php.exe get-fav.php --list=sites.txt --path=icons --save --debug`
`C:\php\php.exe get-fav.php --list=http://www.microsoft.com,http://www.google.com --path=icons --save`

### Notes
I've been testing pretty heavily, I've made some changes but nothing major, adding some more debug entries (mostly for me lol).

There is an issue where sometimes it takes a really long time for a download to fail but I think it's beyond the script and sometimes CURL is not honoring timeouts.



